### PR TITLE
use dynamic primary site handle

### DIFF
--- a/src/services/EntriesContent.php
+++ b/src/services/EntriesContent.php
@@ -73,7 +73,7 @@ class EntriesContent extends BaseContentMigration
         $primaryEntry = Entry::find()
             ->section($data['section'])
             ->slug($data['slug'])
-            ->site('default')
+            ->site(Craft::$app->sites->getPrimarySite()->handle)
             ->first();
 
         if (array_key_exists('parent', $data))


### PR DESCRIPTION
Using 'default' as primary site handle might not always work. In my case: I have 16 sites and the primary site does not have the handle 'default'. Let's use Craft's core method of getting the handle of the primary site dynamically.