### PR TITLE
Fix deprecation error

### DIFF
--- a/src/templates/actions/run.twig
+++ b/src/templates/actions/run.twig
@@ -17,6 +17,6 @@
 {% do view.registerAssetBundle("firstborn\\migrationmanager\\assetbundles\\cp\\CpAssetBundle") %}
 
 
-{% includejs %}
+{% js %}
     new Craft.MigrationManagerRunner({{ data|json_encode|raw }}, '{{ nextAction }}');
-{% endincludejs %}
+{% endjs %}


### PR DESCRIPTION
Changed `{% includejs %}` to` {% js %}` because `{% includejs %}` is deprecated in Craft 3.