### PR TITLE
Fix neo fields in migrations

### DIFF
--- a/src/helpers/MigrationManagerHelper.php
+++ b/src/helpers/MigrationManagerHelper.php
@@ -61,7 +61,8 @@ class MigrationManagerHelper
      */
     public static function getNeoBlockType($handle, $fieldId)
     {
-        $blockTypes = Craft::$app->neo->getBlockTypesByFieldId($fieldId);
+        $neo = Craft::$app->getPlugins()->getPlugin('neo');
+        $blockTypes = $neo->blockTypes->getByFieldId($fieldId);
         foreach ($blockTypes as $block) {
             if ($block->handle == $handle) {
                 return $block;

--- a/src/helpers/MigrationManagerHelper.php
+++ b/src/helpers/MigrationManagerHelper.php
@@ -61,7 +61,7 @@ class MigrationManagerHelper
      */
     public static function getNeoBlockType($handle, $fieldId)
     {
-        $neo = Craft::$app->getPlugins()->getPlugin('neo');
+        $neo = Craft::$app->plugins->getPlugin('neo');
         $blockTypes = $neo->blockTypes->getByFieldId($fieldId);
         foreach ($blockTypes as $block) {
             if ($block->handle == $handle) {

--- a/src/services/BaseContentMigration.php
+++ b/src/services/BaseContentMigration.php
@@ -162,7 +162,7 @@ abstract class BaseContentMigration extends BaseMigration
                              foreach($blockTabs as $blockTab){
                                  $blockFields = $blockTab->getFields();
                                  foreach($blockFields as &$blockTabField){
-                                     $neoBlockField = Craft::$app->fields->getFieldById($blockTabField->fieldId);
+                                     $neoBlockField = Craft::$app->fields->getFieldById($blockTabField->fieldId ?? $blockTabField->id);
                                      if ($neoBlockField->className() == 'verbb\supertable\fields\SuperTableField') {
                                          $neoBlockFieldValue = $neoBlock['fields'][$neoBlockField->handle];
                                          $this->updateSupertableFieldValue($neoBlockFieldValue, $neoBlockField);


### PR DESCRIPTION
Fixed 2 issues regarding the neo fields.

A wrong call to neo was used in the `getNeoBlockType` method. I've fixed it by using the plugins->getPlugin call that is used in other method calls.

Some fields like redactor use `id` instead of `fieldId`. A simple else case has been added for that.